### PR TITLE
fix: forward coleaseum.com → colet.ai (rebrand 301)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+    <!-- Any deep link on coleaseum.com forwards to colet.ai (rebrand). -->
+    <script>location.replace("https://colet.ai/");</script>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://colet.ai/">
+    <link rel="canonical" href="https://colet.ai/">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Colet (formerly Coleaseum)</title>
+</head>
+<body>
+    <p>Coleaseum is now <a href="https://colet.ai/">Colet</a>. Redirecting…</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,11 @@
 <html lang="en-GB">
 <head>
+    <!-- Coleaseum has rebranded to Colet. Forward to colet.ai.
+         The canonical 301 is enforced at the edge via a Cloudflare Single Redirect rule;
+         this client-side forward is the GitHub Pages fallback (runs before paint, no content flash). -->
+    <script>location.replace("https://colet.ai/");</script>
+    <meta http-equiv="refresh" content="0; url=https://colet.ai/">
+    <link rel="canonical" href="https://colet.ai/">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Closes gibouu/colet#23

## What
coleaseum.com (this GitHub Pages site) currently shows a "we rebranded" one-pager but does not redirect. This forwards visitors to **colet.ai**.

## How
GitHub Pages can't emit a server-side 301, so:
- **index.html** — head-level `location.replace("https://colet.ai/")` (runs before paint, no content flash) + `<meta http-equiv=refresh>` no-JS fallback + `rel=canonical`.
- **404.html** — same forward, so any deep link (e.g. old listing URLs) lands on colet.ai instead of a 404.

## The real 301 (needs your Cloudflare access — I have zone:read only)
For a true edge 301 (better for SEO/bots), add a **Cloudflare → Rules → Redirect Rules → Single Redirect** on the coleaseum.com zone:
- **When:** `(http.host eq "coleaseum.com") or (http.host eq "www.coleaseum.com")`
- **Then:** Static redirect → `https://colet.ai/` (or Dynamic `concat("https://colet.ai", http.request.uri.path)` to preserve path) — **Status 301**, Preserve query string on.

Once that rule is live it supersedes this page (the redirect happens at the edge, the HTML never renders). This PR is the working fallback until then.

## Test plan
- [ ] Merge → wait for Pages deploy
- [ ] `curl -sL https://www.coleaseum.com` resolves to colet.ai content / browser lands on colet.ai
- [ ] Hit a random deep path (e.g. `/foo`) → forwards via 404.html
- [ ] (After CF rule) `curl -sI https://coleaseum.com` returns `HTTP/2 301` with `location: https://colet.ai/`

— gib